### PR TITLE
MBL-75 Don't use KAV on Android

### DIFF
--- a/src/components/PostDetails/CommentEditor/CommentEditor.js
+++ b/src/components/PostDetails/CommentEditor/CommentEditor.js
@@ -3,6 +3,7 @@ import { Button, KeyboardAvoidingView } from 'react-native'
 import Editor from '../../Editor'
 import { get } from 'lodash/fp'
 import { keyboardAvoidingViewProps as kavProps } from 'util/viewHelpers'
+import { isIOS } from 'util/platform'
 
 export default class CommentEditor extends React.Component {
   static navigationOptions = ({ navigation }) => {
@@ -33,14 +34,20 @@ export default class CommentEditor extends React.Component {
     if (this.interval) clearInterval(this.interval)
   }
 
-  render () {
+  editorView = () => {
     const { content, navigation } = this.props
-    return <KeyboardAvoidingView style={styles.container} {...kavProps}>
-      <Editor ref={ref => { this.editor = ref }}
-        initialContent={content}
-        navigation={navigation}
-        communityId={navigation.state.params.communityId} />
-    </KeyboardAvoidingView>
+    return <Editor ref={ref => { this.editor = ref }}
+      initialContent={content}
+      navigation={navigation}
+      communityId={navigation.state.params.communityId} />
+  }
+
+  render () {
+    return isIOS
+      ? <KeyboardAvoidingView style={styles.container} {...kavProps}>
+        {this.editorView()}
+      </KeyboardAvoidingView>
+      : this.editorView()
   }
 }
 


### PR DESCRIPTION
This skips `KeyboardAvoidingView` on Android, which doesn't need it in our current configuration, avoiding the buggy behaviour of `CommentEditor` that it causes.

Testing this component, as noted by @levity in the test file, is damn near impossible right now. I gave it a good go to see if things had improved but there just doesn't seem to be a workaround.