### PR TITLE
Placeholder text is better not as a question

### DIFF
--- a/src/components/PostDetails/CommentEditor/CommentEditor.js
+++ b/src/components/PostDetails/CommentEditor/CommentEditor.js
@@ -56,7 +56,7 @@ export default class CommentEditor extends React.Component {
     return <Editor ref={ref => { this.editor = ref }}
       initialContent={content}
       navigation={navigation}
-      placeholder='Add a comment?'
+      placeholder='Add a comment...'
       onChange={content => this.setState({content})}
       communityId={navigation.state.params.communityId} />
   }


### PR DESCRIPTION
In the comment create input box, the placeholder text is "Add a comment?"
This strikes me as odd every time I see it, so I just thought I'd track it down and change it to an ellipsis

And also, I made a PR for this forever ago, but these should DEFINITELY auto-focus into the field