### PR TITLE
Fixes i18n bugs with LocationPicker (Signup), and Group Creation

### DIFF
--- a/src/components/MemberList/MemberList.js
+++ b/src/components/MemberList/MemberList.js
@@ -7,6 +7,7 @@ import {
   View, FlatList, Text, TouchableOpacity
 } from 'react-native'
 import { useIsFocused, useScrollToTop } from '@react-navigation/native'
+import { useTranslation } from 'react-i18next'
 import Avatar from 'components/Avatar'
 import Icon from 'components/Icon'
 import Loading from 'components/Loading'
@@ -14,7 +15,6 @@ import PopupMenuButton from 'components/PopupMenuButton'
 import styles from './MemberList.styles'
 import SearchBar from 'components/SearchBar'
 import CondensingBadgeRow from '../CondensingBadgeRow/CondensingBadgeRow'
-import { useTranslation } from 'react-i18next'
 
 export class MemberList extends React.Component {
   static defaultProps = {
@@ -98,7 +98,7 @@ export class MemberList extends React.Component {
     t('Newest')
     t('Name')
     t('Location')
-    
+
     const header = (
       <View>
         {children || null}
@@ -153,7 +153,7 @@ export function Member ({ member, showMember, group }) {
   const { moderatedGroupMemberships, groupRoles, id } = member
   const badges = (group && groupRoles.filter(role => role.groupId === group.id)) || []
   const creatorIsModerator = moderatedGroupMemberships.find(moderatedMembership => moderatedMembership.groupId === group?.id)
-  
+
   return (
     <TouchableOpacity
       onPress={() => isFunction(showMember) && showMember(member.id)}

--- a/src/screens/CreateGroupFlow/CreateGroupReview.js
+++ b/src/screens/CreateGroupFlow/CreateGroupReview.js
@@ -4,6 +4,7 @@ import {
   Text, View, TextInput, ScrollView, TouchableOpacity
 } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
+import { useTranslation } from 'react-i18next'
 import { openURL } from 'hooks/useOpenURL'
 import ErrorBubble from 'components/ErrorBubble'
 import { accessibilityDescription, visibilityDescription } from 'store/models/Group'
@@ -15,7 +16,6 @@ import {
 } from './CreateGroupFlow.store'
 import { white } from 'style/colors'
 import styles from './CreateGroupFlow.styles'
-import { useTranslation } from 'react-i18next'
 
 export default function CreateGroupReview () {
   const { t } = useTranslation()
@@ -24,7 +24,6 @@ export default function CreateGroupReview () {
   const groupData = useSelector(getGroupData)
   const parentGroups = useSelector(getNewGroupParentGroups)
   const [error, setError] = useState(null)
-
 
   useEffect(() => {
     return navigation.addListener('tabPress', async event => {
@@ -60,7 +59,7 @@ export default function CreateGroupReview () {
           <View style={styles.textInputContainer}>
             <View style={stepStyles.itemHeader}>
               <Text style={stepStyles.textInputLabel}>{t('Whats the name of your group?')}</Text>
-              <EditButton t={t} onPress={() => navigation.navigate('CreateGroupName')} />
+              <EditButton onPress={() => navigation.navigate('CreateGroupName')} />
             </View>
             <TextInput
               style={stepStyles.reviewTextInput}
@@ -156,11 +155,15 @@ const GroupRow = ({ group }) => (
   </View>
 )
 
-const EditButton = ({ onPress, t }) => (
-  <TouchableOpacity onPress={onPress}>
-    <Text style={stepStyles.editLink}>{t('Edit')}</Text>
-  </TouchableOpacity>
-)
+const EditButton = ({ onPress }) => {
+  const { t } = useTranslation()
+
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <Text style={stepStyles.editLink}>{t('Edit')}</Text>
+    </TouchableOpacity>
+  )
+}
 
 const stepStyles = {
   textInputLabel: {

--- a/src/screens/LocationPicker/LocationPicker.js
+++ b/src/screens/LocationPicker/LocationPicker.js
@@ -1,18 +1,17 @@
 import { isObject } from 'lodash/fp'
-import { useTranslation } from 'react-i18next'
 import { locationSearch } from 'screens/LocationPicker/LocationPicker.store'
 import LocationPickerItemRow from 'screens/LocationPicker/LocationPickerItemRow'
 
 export default function LocationPicker ({
-  screenTitle = 'Choose a Location',
+  screenTitle: providedScreenTitle,
   navigation,
   currentLocation,
   initialSearchTerm = '',
-  onPick
+  onPick,
+  t
 }) {
-  const { t } = useTranslation()
   navigation.navigate('ItemChooser', {
-    screenTitle,
+    screenTitle: t(providedScreenTitle || 'Choose a Location'),
     searchPlaceholder: t('Search for your location'),
     initialSearchTerm,
     ItemRowComponent: LocationPickerItemRow,

--- a/src/screens/MemberProfile/MemberHeader.js
+++ b/src/screens/MemberProfile/MemberHeader.js
@@ -4,6 +4,7 @@ import {
   TouchableOpacity,
   Alert
 } from 'react-native'
+import { useTranslation } from 'react-i18next'
 import Icon from 'components/Icon'
 import PopupMenuButton from 'components/PopupMenuButton'
 import { filter, get, isEmpty } from 'lodash/fp'
@@ -11,7 +12,6 @@ import styles from './MemberHeader.styles'
 import { AXOLOTL_ID } from 'store/models/Person'
 import LocationPicker from 'screens/LocationPicker/LocationPicker'
 import Control from 'screens/MemberProfile/Control'
-import { useTranslation } from 'react-i18next'
 
 export default function MemberHeader ({
   person,
@@ -43,7 +43,8 @@ export default function MemberHeader ({
       onPick: location => {
         updateSetting('location', location?.fullText)
         updateSetting('locationId', location?.id)
-      }
+      },
+      t
     })
   }
 

--- a/src/screens/MemberProfile/MemberProfile.js
+++ b/src/screens/MemberProfile/MemberProfile.js
@@ -3,6 +3,7 @@ import { Text, View, TouchableOpacity } from 'react-native'
 import FastImage from 'react-native-fast-image'
 import { useNavigation } from '@react-navigation/native'
 import useIsModalScreen from 'hooks/useIsModalScreen'
+import { useTranslation, withTranslation } from 'react-i18next'
 import Loading from 'components/Loading'
 import MemberFeed from './MemberFeed'
 import MemberHeader from './MemberHeader'
@@ -12,7 +13,6 @@ import EntypoIcon from 'react-native-vector-icons/Entypo'
 import defaultBanner from 'assets/default-user-banner.jpg'
 import styles from './MemberProfile.styles'
 import ModalHeaderTransparent from 'navigation/headers/ModalHeaderTransparent'
-import { withTranslation } from 'react-i18next'
 
 export const blockUserWithNav = async ({ navigation, person, blockUser }) => {
   await blockUser(person.id)
@@ -96,7 +96,7 @@ function MemberProfile ({
           goToManageNotifications={goToManageNotifications}
           goToBlockedUsers={goToBlockedUsers}
         />
-        <ReadMoreButton goToDetails={goToDetails} t={t} />
+        <ReadMoreButton goToDetails={goToDetails} />
       </View>
       {flaggingVisible && (
         <FlagContent
@@ -167,7 +167,9 @@ export class MemberBanner extends React.Component {
           disabled={!isMe}
         >
           <FastImage source={bannerSource} style={styles.bannerImage} />
-          {isMe && <EditButton isLoading={bannerPickerPending} style={styles.bannerEditButton} t={t} />}
+          {isMe && (
+            <EditButton isLoading={bannerPickerPending} style={styles.bannerEditButton} />
+          )}
         </ImagePicker>
         <View style={styles.avatarW3}>
           <ImagePicker
@@ -190,7 +192,9 @@ export class MemberBanner extends React.Component {
   }
 }
 
-export function EditButton ({ isLoading, style, t }) {
+export function EditButton ({ isLoading, style }) {
+  const { t } = useTranslation()
+
   return (
     <View style={[styles.editButton, style]}>
       {isLoading
@@ -206,7 +210,9 @@ export function EditButton ({ isLoading, style, t }) {
   )
 }
 
-export function ReadMoreButton ({ goToDetails, t }) {
+export function ReadMoreButton ({ goToDetails }) {
+  const { t } = useTranslation()
+
   return (
     <View style={styles.buttonContainer}>
       <TouchableOpacity onPress={goToDetails} style={styles.buttonWrapper}>

--- a/src/screens/PostEditor/PostEditor.js
+++ b/src/screens/PostEditor/PostEditor.js
@@ -12,6 +12,7 @@ import {
 } from 'react-native'
 import RNPickerSelect from 'react-native-picker-select'
 import { useIsFocused } from '@react-navigation/native'
+import { useTranslation } from 'react-i18next'
 import { get, uniq, uniqBy, isEmpty } from 'lodash/fp'
 import moment from 'moment-timezone'
 import { Validators, TextHelpers } from 'hylo-shared'
@@ -46,7 +47,6 @@ import styles, { typeSelectorStyles } from './PostEditor.styles'
 import HeaderLeftCloseIcon from 'navigation/headers/HeaderLeftCloseIcon'
 import confirmDiscardChanges from 'util/confirmDiscardChanges'
 import { caribbeanGreen, rhino30, rhino80, white } from 'style/colors'
-import { useTranslation } from 'react-i18next'
 
 const titlePlaceholders = {
   discussion: 'Create a post',
@@ -409,7 +409,8 @@ export class PostEditor extends React.Component {
     LocationPicker({
       navigation: this.props.navigation,
       initialSearchTerm: this.state?.location,
-      onPick: this.handlePickLocation
+      onPick: this.handlePickLocation,
+      t
     })
   }
 
@@ -492,7 +493,7 @@ export class PostEditor extends React.Component {
   }
 
   renderForm = () => {
-    const { canModerate, post, postLoading, t } = this.props
+    const { post, postLoading, t } = this.props
     const {
       isSaving, topics, title, type, filePickerPending, announcementEnabled,
       titleLengthError, members, groups, startTime, endTime, location, donationsLink,

--- a/src/screens/Signup/SignupSetLocation/SignupSetLocation.js
+++ b/src/screens/Signup/SignupSetLocation/SignupSetLocation.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { ScrollView, View, Text } from 'react-native'
 import { useFocusEffect } from '@react-navigation/native'
 import { useDispatch, useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
 import { AnalyticsEvents } from 'hylo-shared'
 import useCurrentLocation from 'hooks/useCurrentLocation'
 import getMe from 'store/selectors/getMe'
@@ -13,7 +14,6 @@ import Button from 'components/Button'
 import SettingControl from 'components/SettingControl'
 import LocationPicker from 'screens/LocationPicker/LocationPicker'
 import styles from './SignupSetLocation.styles'
-import { useTranslation } from 'react-i18next'
 
 export default function SignupSetLocation ({ navigation }) {
   const { t } = useTranslation()
@@ -52,7 +52,8 @@ export default function SignupSetLocation ({ navigation }) {
       onPick: pickedLocation => {
         setLocation(pickedLocation?.fullText)
         pickedLocation?.id !== 'NEW' && setLocationId(pickedLocation?.id)
-      }
+      },
+      t
     })
   }
 

--- a/src/store/actions/checkLogin.js
+++ b/src/store/actions/checkLogin.js
@@ -19,6 +19,7 @@ export default function checkLogin () {
               digestFrequency
               dmNotifications
               commentNotifications
+              locale
               signupInProgress
               streamChildPosts
               streamViewMode


### PR DESCRIPTION
* LocationPicker was calling the `useTranslation` hook but is a plain function and not a React component so it is not usable there.  This was breaking Signup and another place or two. 
* In Group Signup and a couple other places `t` was being passed to a couple small inline components  (`Edit Button`, etc), but not done so consistently. This was causing Group Signup to crash. Replaced in all instances with direct use of `useTranslation` in those small components. 
* Also a bit of tidy-up, but mostly just moving the `import { useTranslation, ... } ...` up top to correspond to the general pattern of the imports in the App to date. This is not a comprehensive tidy-up, mostly just the files I touched. I'll be moving these up when I see them in other PRs. 