### PR TITLE
Update linking configuration to exclude redirected hylo.com URLs

### DIFF
--- a/src/components/HyloHTML/HyloHTML.js
+++ b/src/components/HyloHTML/HyloHTML.js
@@ -14,7 +14,7 @@ const wrapInHTMLDoc = source => {
     <html>
     <head>
       <meta charset="utf-8">
-      <base href="https://hylo.com">
+      <base href="https://www.hylo.com">
     </head>
     <body>
       ${source}

--- a/src/navigation/linking/index.js
+++ b/src/navigation/linking/index.js
@@ -99,14 +99,10 @@ export const initialRouteNamesConfig = {
   'Messages Tab': 'Messages'
 }
 
-export const DEFAULT_APP_HOST = 'https://hylo.com'
+export const DEFAULT_APP_HOST = 'https://www.hylo.com'
 
 export const prefixes = [
   DEFAULT_APP_HOST,
-  'http://hylo.com',
-  'http://www.hylo.com',
-  'https://www.hylo.com',
-  'http://staging.hylo.com',
   'https://staging.hylo.com',
   'hyloapp://'
 ]


### PR DESCRIPTION
I have not been able to find anything that could constitute multiple Google Play Store "violations" other than the recent complaining they've been doing about these extra redirected URLs not being validated as owned by us. Removing them, which I THINK will have no effect. 

To confirm that we don't need these extra URLs in the linking configuration try the following on an actual Android device using the BitRise build for this PR:

https://hylo.com/post/75693 and http://hylo.com/post/75693

Both of those URLs will redirect to https://www.hylo.com/post/75693 which should then forward to the app. 