### PR TITLE
DRAFT: Pin to yarn 1.22.22 to make corepack happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,5 +247,6 @@
         "webview"
       ]
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
If for some reason we decide to not go to Yarn 4, this will pin us to 1.22 using Corepack.